### PR TITLE
Make the Endless Cake unbreakable

### DIFF
--- a/src/main/java/dev/elexi/hugeblank/endless_cake/block/EndlessCakeBlock.java
+++ b/src/main/java/dev/elexi/hugeblank/endless_cake/block/EndlessCakeBlock.java
@@ -25,7 +25,7 @@ public class EndlessCakeBlock extends Block {
 
     public static final VoxelShape CAKE_SHAPE = Block.createCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 8.0D, 15.0D);
     public EndlessCakeBlock() {
-        super(Settings.of(Material.CAKE).strength(0.5F).sounds(BlockSoundGroup.WOOL));
+        super(Settings.of(Material.CAKE).strength(-1.0f, 3600000.0f).dropsNothing().sounds(BlockSoundGroup.WOOL));
         this.setDefaultState(this.stateManager.getDefaultState());
     }
 


### PR DESCRIPTION
I think that it would be good to make the Endless Cake unbreakable because someone might want to test if it breaks or someone accidentally breaks it and then no one could use it because there's only one dragon egg in the world. But if for some reason someone really needs to break it, they can still do it using a piston.